### PR TITLE
Make sure we're depending on 'jar' task to create the actual jar

### DIFF
--- a/totpauth-impl/build.gradle
+++ b/totpauth-impl/build.gradle
@@ -45,7 +45,7 @@ task copyDeps(type: Copy) {
   into 'build/libs'
 }
 
-task copyResources(type: Copy, dependsOn: compileJava) {
+task copyResources(type: Copy, dependsOn: 'jar') {
     from 'src/main/resources'
     into 'build/zip'
 }


### PR DESCRIPTION
Turns out, we're weren't creating the actual jar, just compiling the classes..

@rogeruiz 