### PR TITLE
Plain language for token screen

### DIFF
--- a/totpauth-impl/src/main/resources/views/totp-register.vm
+++ b/totpauth-impl/src/main/resources/views/totp-register.vm
@@ -38,9 +38,9 @@ p.error {
           #end
           <form action="$flowExecutionUrl" method="post">
 
-            <li> Download the Google Authenticator to your mobile device </li>
-            <li> Open the app and scan the QR-image or manually enter code: <strong>$sharedSecret</strong></li>
-            <li> Enter the generated Token Code in the box below the QR-image and click <b>Register</b></li>
+            <li> Download the Google Authenticator app to your mobile device </li>
+            <li> Open the app and scan the barcode image below or manually enter this key: <strong>$sharedSecret</strong></li>
+            <li> The app will generate a token code for you. Enter the generated token code in the box below the barcode image and click <b>Register</b></li>
             <br>
             <div class="form-element-wrapper">
                <center><img src="$totpUrl" height="166" width="166"></center>


### PR DESCRIPTION
Google Authenticator uses the terms "barcode" and "key", so let's make our instructions match those terms. Using the separate terms "key" and "token code" (instead of "code" and "token code") should prevent users from thinking they should copy-paste their key into this interface.

I don't have a good way to test this locally, so I'm just hoping this looks ok when rendered.