### PR TITLE
More specific instructions for finding token code

### DIFF
--- a/totpauth-impl/src/main/resources/views/totp.vm
+++ b/totpauth-impl/src/main/resources/views/totp.vm
@@ -34,7 +34,7 @@ p.error {
            <form action="$flowExecutionUrl" method="post">
 
             <div class="form-element-wrapper">
-              <label for="tokenNumber">Temporary token code from your authentication app</label>
+              <label for="tokenNumber">Temporary token code from your authentication app (for most people this is the Google Authenticator app you installed on your mobile phone during account creation)</label>
               <input class="form-element form-field" id="j_tokenNumber" name="j_tokenNumber" type="text" autofocus>
             </div>
 


### PR DESCRIPTION
People keep getting confused about where to find the token code ([example](https://cloud-gov.zendesk.com/agent/tickets/932)), so this is an effort to make the instructions a little more specific.

This will probably end up looking awkward as a very long label, but I figure it's better to do the awkward quick version instead of attempting to add more HTML and possibly breaking something.