### PR TITLE
https ftw

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ subprojects {
     maven { url "https://build.shibboleth.net/nexus/content/groups/public" }
     maven { url "https://build.shibboleth.net/nexus/content/repositories/snapshots" }
     maven { url "https://build.shibboleth.net/nexus/content/repositories/thirdparty-snapshots" }
-    maven { url "http://repo1.maven.org/maven2" }
+    maven { url "https://repo1.maven.org/maven2" }
   }
 
 


### PR DESCRIPTION
We need to use https to pull from maven now, which is good.

# Security Considerations
This makes us more secure, by using https when downloading dependencies